### PR TITLE
Fix SemVer pre-release comparison

### DIFF
--- a/modules/semver.js
+++ b/modules/semver.js
@@ -136,10 +136,13 @@ export const compareSemVer = (version, base, strict = false) => {
       while (i < l) {
         const vPart = vPreParts[i];
         const bPart = bPreParts[i];
-        if ((vPart && !bPart) || (isString(vPart) && Number.isInteger(bPart))) {
+        if (vPart === undefined && bPart !== undefined) {
+          result = -1;
+        } else if (vPart !== undefined && bPart === undefined) {
           result = 1;
-        } else if ((!vPart && bPart) ||
-                   (Number.isInteger(vPart) && isString(bPart))) {
+        } else if (isString(vPart) && Number.isInteger(bPart)) {
+          result = 1;
+        } else if (Number.isInteger(vPart) && isString(bPart)) {
           result = -1;
         } else if (vPart !== bPart && isString(vPart) && isString(bPart)) {
           result = vPart < bPart ? -1 : 1;

--- a/test/semver.test.js
+++ b/test/semver.test.js
@@ -462,6 +462,10 @@ describe('Compare SemVer', () => {
   it('should be less than 0 (ASCII sort order: "-" < "a")', () => {
     assert.strictEqual(compareSemVer('1.0.0--', '1.0.0-a') < 0, true);
   });
+
+  it('should be less than 0', () => {
+    assert.strictEqual(compareSemVer('1.0.0-a', '1.0.0-a.0') < 0, true);
+  });
 });
 
 describe('Parse SemVer', () => {


### PR DESCRIPTION
Use explicit undefined checks when comparing pre-release parts to avoid incorrect results from truthy/falsy checks. Reordered branches to correctly handle numeric vs string identifiers and set result accordingly. Added a test asserting that '1.0.0-a' is less than '1.0.0-a.0' to cover the undefined-part comparison case.